### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Change tintColor DSXActivityIndicator (UIView)
 * Delegate to listen for user interactions
 
 ## About
-This simple exercise was a means to practice Cocoapods techniques whilst also sharing _something_ that others might find useful.  
+This simple exercise was a means to practice CocoaPods techniques whilst also sharing _something_ that others might find useful.  
   
 Please feel free to use for any purpose.  
 I would love to hear from you, especially if you use DSXActivityIndicator in any of your projects.  


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
